### PR TITLE
Added ability to set context name for SNMP variables

### DIFF
--- a/example_agent.py
+++ b/example_agent.py
@@ -181,8 +181,10 @@ agent.start()
 # Helper function that dumps the state of all registered SNMP variables
 def DumpRegistered():
 	print "{0}: Registered SNMP objects: ".format(prgname)
-	vars = agent.getRegistered()
-	pprint.pprint(vars, width=columns)
+	for context in agent.getContexts():
+		vars = agent.getRegistered(context)
+		print "{0}: Context '{1}': ".format(prgname, context)
+		pprint.pprint(vars, width=columns)
 DumpRegistered()
 
 # Install a signal handler that terminates our example agent when

--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -650,15 +650,19 @@ class netsnmpAgent(object):
 		# Return an instance of the just-defined class to the agent
 		return Table(oidstr, indexes, columns, counterobj, extendable, context)
 
-	def getRegistered(self):
-		""" Returns a dictionary with the currently registered SNMP objects. """
-		myobjs = defaultdict(dict)
-		for context, objs in self._objs.iteritems():
-			for oidstr, snmpobj in objs.iteritems():
-				myobjs[context][oidstr] = {
-					"type": type(snmpobj).__name__,
-					"value": snmpobj.value()
-				}
+	def getContexts(self):
+		return self._objs.keys()
+
+	def getRegistered(self, context = ""):
+		"""Returns a dictionary with the currently registered SNMP objects.
+		Returned is a dictionary objects for the specified `context`, which
+		defaults to the default context ""."""
+		myobjs = {}
+		for oidstr, snmpobj in self._objs[context].iteritems():
+			myobjs[oidstr] = {
+				"type": type(snmpobj).__name__,
+				"value": snmpobj.value()
+			}
 		return dict(myobjs)
 
 	def start(self):


### PR DESCRIPTION
Hi Pieter,

I've added the ability to set a non default context name for SNMP variables.

One change which may be a bit more controversial is my use of the _objs_ attribute:  `agent._objs[context][oidstr]` which could break someone's code, but I couldn't think of a neater way to do it. `agent.getRegistered()['']` gives same behaviour as before.
