### PR TITLE
Handle wrap of 32bit and 64bit counters

### DIFF
--- a/example_agent.py
+++ b/example_agent.py
@@ -97,9 +97,9 @@ exampleCounter32 = agent.Counter32(
 	oidstr = "EXAMPLE-MIB::exampleCounter32"
 )
 exampleCounter32Context2 = agent.Counter32(
-	oidstr = "EXAMPLE-MIB::exampleInteger",
+	oidstr = "EXAMPLE-MIB::exampleCounter32",
 	context = "context2",
-	initval = 100,
+	initval = pow(2,32) - 10,
 )
 exampleCounter64 = agent.Counter64(
 	oidstr = "EXAMPLE-MIB::exampleCounter64"

--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -261,6 +261,10 @@ class netsnmpAgent(object):
 					                                else self._cvar
 
 				def update(self, val):
+					if self._asntype == ASN_COUNTER and val >> 32:
+						val = val & 0xFFFFFFFF
+					if self._asntype == ASN_COUNTER64 and val >> 64:
+						val = val & 0xFFFFFFFFFFFFFFFF
 					self._cvar.value = val
 					if props["flags"] == WATCHER_SIZE_STRLEN:
 						if len(val) > self._max_size:


### PR DESCRIPTION
Warning messages are printed to the stderr when counters exceed max value: e.g. "truncating integer value > 32 bits".

This pull request resolves this by checking if snmp object is a counter, and then wraps the value if it exceeds the max value.
