### PR TITLE
Fix counter64 incorrectly setting low and high in c structure

### DIFF
--- a/example_agent.py
+++ b/example_agent.py
@@ -101,6 +101,11 @@ exampleCounter32Context2 = agent.Counter32(
 	context = "context2",
 	initval = pow(2,32) - 10,
 )
+exampleCounter64Context2 = agent.Counter64(
+	oidstr = "EXAMPLE-MIB::exampleCounter64",
+	context = "context2",
+	initval = pow(2,64) - 10,
+)
 exampleCounter64 = agent.Counter64(
 	oidstr = "EXAMPLE-MIB::exampleCounter64"
 )
@@ -217,5 +222,6 @@ while (loop):
 	exampleCounter64.update(exampleCounter64.value() + 4294967294)
 	exampleTimeTicks.update(exampleTimeTicks.value() + 1)
 	exampleCounter32Context2.update(exampleCounter32Context2.value() + 1)
+	exampleCounter64Context2.update(exampleCounter64Context2.value() + 1)
 
 print "{0}: Terminating.".format(prgname)

--- a/netsnmpapi.py
+++ b/netsnmpapi.py
@@ -10,9 +10,6 @@ import ctypes, ctypes.util
 
 c_sizet_p = ctypes.POINTER(ctypes.c_size_t)
 
-# <limits.h>
-UINT_MAX = 4294967295
-
 # Make libnetsnmpagent available via Python's ctypes module. We do this globally
 # so we can define C function prototypes
 
@@ -165,12 +162,12 @@ ASN_APPLICATION                         = 0x40
 class counter64(ctypes.Structure):
 	@property
 	def value(self):
-		return self.high * UINT_MAX + self.low
+		return self.high << 32 | self.low
 
 	@value.setter
 	def value(self, val):
-		self.high = val / UINT_MAX
-		self.low  = val - self.high * UINT_MAX
+		self.high = val >> 32
+		self.low  = val & 0xFFFFFFFF
 
 	def __init__(self, initval=0):
 		ctypes.Structure.__init__(self, 0, 0)


### PR DESCRIPTION
I found in testing with large 64bits integers, that whilst the values looked correct in python, they were wrong in snmpwalk. 

I've tweaked the setting of low and high and the value is now match in both snmpwalk and python 
