### PR TITLE
Add increment method to asntypes COUNTER and COUNTER64

### DIFF
--- a/example_agent.py
+++ b/example_agent.py
@@ -221,7 +221,8 @@ while (loop):
 	exampleCounter32.update(exampleCounter32.value() + 2)
 	exampleCounter64.update(exampleCounter64.value() + 4294967294)
 	exampleTimeTicks.update(exampleTimeTicks.value() + 1)
-	exampleCounter32Context2.update(exampleCounter32Context2.value() + 1)
-	exampleCounter64Context2.update(exampleCounter64Context2.value() + 1)
+	# With Counters, you can also increment them
+	exampleCounter32Context2.increment() # By 1
+	exampleCounter64Context2.increment(5) # By 5
 
 print "{0}: Terminating.".format(prgname)

--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -274,6 +274,10 @@ class netsnmpAgent(object):
 						self._cvar.value = val
 						self._data_size  = len(val)
 
+				if props['asntype'] in [ASN_COUNTER, ASN_COUNTER64]:
+					def increment(self, count=1):
+						self.update(self.value() + count)
+
 			cls.__name__ = property_func.__name__
 
 			# Return an instance of the just-defined class to the agent


### PR DESCRIPTION
I've added a method to the Counter32 and Counter64 types for incrementing the values, as I found myself using `exampleCounter32.update(exampleCounter32.value() + 1)` quite a few times.

Default increment is 1, but can pass integer argument to increment by more.
