### PR TITLE
Fix pief/python-netsnmpagent#8: Set watcher data_size on update()

### DIFF
--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -230,18 +230,18 @@ class netsnmpAgent(object):
 						handler_reginfo.contents.contextName = context
 
 						# Create the netsnmp_watcher_info structure.
-						watcher = libnsX.netsnmp_create_watcher_info(
+						self.watcher = libnsX.netsnmp_create_watcher_info(
 							self.cref(),
 							self._data_size,
 							self._asntype,
 							self._flags
 						)
-						watcher.max_size = self._max_size
+						self.watcher.contents.max_size = self._max_size
 
 						# Register handler and watcher with net-snmp.
 						result = libnsX.netsnmp_register_watched_scalar(
 							handler_reginfo,
-							watcher
+							self.watcher
 						)
 						if result != 0:
 							raise netsnmpAgentException("Error registering variable with net-snmp!")
@@ -272,7 +272,7 @@ class netsnmpAgent(object):
 								"Value passed to update() truncated: {0} > {1} "
 								"bytes!".format(len(val), self._max_size))
 						self._cvar.value = val
-						self._data_size  = len(val)
+						self._data_size  = self.watcher.contents.data_size = len(val)
 
 				if props["asntype"] in [ASN_COUNTER, ASN_COUNTER64]:
 					def increment(self, count=1):

--- a/netsnmpapi.py
+++ b/netsnmpapi.py
@@ -195,6 +195,13 @@ WATCHER_SIZE_STRLEN                     = 0x08
 
 class netsnmp_watcher_info(ctypes.Structure): pass
 netsnmp_watcher_info_p = ctypes.POINTER(netsnmp_watcher_info)
+netsnmp_watcher_info._fields_ = [
+	("data",                ctypes.c_void_p),
+	("data_size",           ctypes.c_size_t),
+	("max_size",            ctypes.c_size_t),
+	("type",                ctypes.c_ubyte),
+	("flags",               ctypes.c_int)
+]
 
 for f in [ libnsX.netsnmp_create_watcher_info ]:
 	f.argtypes = [


### PR DESCRIPTION
There are actually three small issues here:
- `libnsX.netsnmp_watcher_info` structure doesn't have any `_fields_` so watcher.contents is empty
- setting `watcher.max_size` (instead of `watcher.contents.max_size`) silently does nothing
- `WATCHER_SIZE_STRLEN` flag doesn't exist in net-snmp < 5.7 so `data_size` was getting set once and never updating.

This pull request fixes all three.  The one caveat is on net-snmp 5.7, there's another field in netsnmp_watcher_info that I've left out.   It's not explicitely used so I felt it was safe to do so.  For completion/correctness, it can be added but only if version is < 5.7, which can be tested with something like:

``` python
libns  = ctypes.cdll.LoadLibrary(ctypes.util.find_library("netsnmp"))
for f in [ libns.netsnmp_get_version ]:
        f.argtypes = []
        f.restype = ctypes.c_char_p

version = tuple(int(i) for i in libns.netsnmp_get_version().split('.'))
print version, version < (5, 7)
```

But that felt like a lot of code for not very much gain.
