### PR TITLE
setup: Add classifiers, link to Github repo.

### DIFF
--- a/setup.py.in
+++ b/setup.py.in
@@ -32,4 +32,15 @@ and data types of the information within the MIB module.""",
 	author_email		= "pieter@hollants.com",
 	py_modules			= [ "netsnmpagent", "netsnmpapi" ],
 	license				= "GPL-3.0",
+        url                             = "https://github.com/pief/python-netsnmpagent",
+        classifiers                     =[
+               'Intended Audience :: Developers',
+               'Natural Language :: English',
+               'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+               'Operating System :: POSIX',
+               'Programming Language :: Python :: 2',
+               'Programming Language :: Python :: 2.6',
+               'Programming Language :: Python :: 2.7',
+               'Topic :: Software Development :: Libraries'
+               ],
 )


### PR DESCRIPTION
This adds a few things to the `setup.py.in`. First of all a URL at which the project can be found when people are browsing through PyPi.

Second a set of classifiers that classify this project and should make it easier to find.
