### PR TITLE
fix snmp table returning wrong counter64 value

### DIFF
--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -841,6 +841,8 @@ class netsnmpAgent(object):
 						if bool(data.contents.data):
 							if data.contents.type == ASN_OCTET_STR:
 								retdict[indices][int(data.contents.column)] = ctypes.string_at(data.contents.data.string, data.contents.data_len)
+							elif data.contents.type == ASN_COUNTER64:
+								retdict[indices][int(data.contents.column)] = data.contents.data.counter64.contents.value
 							else:
 								retdict[indices][int(data.contents.column)] = data.contents.data.integer.contents.value
 						else:


### PR DESCRIPTION
Hi Pieter,

Here is a patch to issue I hit recently.

To generate traps I am creating a cache table that I am checking against the fresh populated one, if there is a change I am issuing send_trap() to notify for the change. Here I hit the bug - only one half of the the counter64 value is returned. After some tests I found the root and I am proposing a patch that is solving the issue.

Kind Regards,
Anton Todorov