### PR TITLE
Allow IpAddress objects to be used as table index.

### DIFF
--- a/examples/SIMPLE-MIB.txt
+++ b/examples/SIMPLE-MIB.txt
@@ -265,6 +265,69 @@ secondTableEntryValue OBJECT-TYPE
         "An secondTableEntry's value."
     ::= { secondTableEntry 3 }
 
+    
+
+    
+thirdTableNumber OBJECT-TYPE
+    SYNTAX      Unsigned32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "The number of entries in thirdTable."
+    ::= { simpleTables 5 }
+
+thirdTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF FirstTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The first simple table"
+    ::= { simpleTables 6 }
+
+FirstTableEntry ::=
+    SEQUENCE {
+        thirdTableEntryIndex  IpAddress,
+        thirdTableEntryDesc   DisplayString,
+        thirdTableEntryValue  Integer32
+    }
+
+thirdTableEntry OBJECT-TYPE
+    SYNTAX      FirstTableEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A particular thirdTable row."
+    INDEX { thirdTableEntryIndex }
+    ::= { thirdTable 1 }
+
+thirdTableEntryIndex OBJECT-TYPE
+    SYNTAX      IpAddress
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "The index column used to generate string indices into
+        thirdTable."
+    ::= { thirdTableEntry 1 }
+
+thirdTableEntryDesc OBJECT-TYPE
+    SYNTAX      DisplayString
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A thirdTableEntry's description."
+    ::= { thirdTableEntry 2 }
+
+thirdTableEntryValue OBJECT-TYPE
+    SYNTAX      Integer32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "A thirdTableEntry's value."
+    ::= { thirdTableEntry 3 }
+
+
+    
+
 ------------------------------------------------------------------------
 -- Notifications
 ------------------------------------------------------------------------

--- a/examples/simple_agent.py
+++ b/examples/simple_agent.py
@@ -190,6 +190,34 @@ secondTableRow2 = secondTable.addRow([agent.Integer32(2)])
 secondTableRow2.setRowCell(2, agent.DisplayString("foo1"))
 secondTableRow2.setRowCell(3, agent.Unsigned32(12842))
 
+# Create the third table
+thirdTable = agent.Table(
+	oidstr = "SIMPLE-MIB::thirdTable",
+	indexes = [
+		agent.IpAddress()
+	],
+	columns = [
+		(2, agent.DisplayString("Broadcast")),
+		(3, agent.IpAddress("192.168.0.255"))
+	],
+	counterobj = agent.Unsigned32(
+		oidstr = "SIMPLE-MIB::thirdTableNumber"
+	)
+)
+
+# Add the first table row
+thirdTableRow1 = thirdTable.addRow([agent.IpAddress("192.168.0.1")])
+thirdTableRow1.setRowCell(2, agent.DisplayString("Host 1"))
+thirdTableRow1.setRowCell(3, agent.IpAddress("192.168.0.1"))
+
+# Add the second table row
+thirdTableRow2 = thirdTable.addRow([agent.IpAddress("192.168.0.2")])
+thirdTableRow2.setRowCell(2, agent.DisplayString("Host 2"))
+thirdTableRow2.setRowCell(3, agent.IpAddress("192.168.0.2"))
+
+# Add the third table row
+thirdTableRow3 = thirdTable.addRow([agent.IpAddress("192.168.0.3")])
+
 # Finally, we tell the agent to "start". This actually connects the
 # agent to the master agent.
 try:

--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -469,7 +469,7 @@ class netsnmpAgent(object):
 						val = int(val)
 					return val
 
-				def cref(self):
+				def cref(self, **kwargs):
 					return ctypes.byref(self._cvar) if self._flags == WATCHER_FIXED_SIZE \
 					                                else self._cvar
 
@@ -578,9 +578,13 @@ class netsnmpAgent(object):
 
 		class IpAddress(object):
 			def __init__(self):
+				self._flags = WATCHER_FIXED_SIZE
+				self._asntype = ASN_IPADDRESS
 				self._cvar = ctypes.c_uint(0)
+				self._data_size = ctypes.sizeof(self._cvar)
+				self._max_size  = self._data_size
 				self.update(initval)
-				
+
 				if oidstr:
 					# Prepare the netsnmp_handler_registration structure.
 					handler_reginfo = agent._prepareRegistration(oidstr, writable)
@@ -608,14 +612,24 @@ class netsnmpAgent(object):
 					agent._objs[context][oidstr] = self
 
 			def value(self):
+				# Get string representation of IP address.
 				return socket.inet_ntoa(
 					struct.pack("I", self._cvar.value)
 				)
 
-			def cref(self):
-				return ctypes.byref(self._cvar)
+			def cref(self, **kwargs):
+				# Get a reference to where IP address is stored.
+				if kwargs.get('is_table_index', False) == False:
+					return ctypes.byref(self._cvar)
+				else:
+					# Due to an open Net-SNMP issue we have to convert the value to
+					# host byte order if it shall be used as table index.
+					_cidx = ctypes.c_uint(0)
+					_cidx.value = struct.unpack("I", struct.pack("!I", self._cvar.value))[0]
+					return ctypes.byref(_cidx)
 
 			def update(self, val):
+				# Convert dotted decimal IP address string to ctypes unsigned int in network byte order.
 				self._cvar.value = struct.unpack(
 					"I",
 					socket.inet_aton(val)
@@ -711,7 +725,7 @@ class netsnmpAgent(object):
 								None,
 								0,
 								idxobj._asntype,
-								idxobj.cref(),
+								idxobj.cref(is_table_index=True),
 								idxobj._data_size
 							)
 							if result == None:
@@ -767,6 +781,12 @@ class netsnmpAgent(object):
 					if bool(col.contents.data):
 						if col.contents.type == ASN_OCTET_STR:
 							retdict[0][int(col.contents.column)]["value"] = ctypes.string_at(col.contents.data.string, col.contents.data_len)
+						elif col.contents.type == ASN_IPADDRESS:
+							uint_value = ctypes.cast(
+								(ctypes.c_int*1)(col.contents.data.integer.contents.value),
+								ctypes.POINTER(ctypes.c_uint)
+								).contents.value
+							retdict[0][int(col.contents.column)]["value"] = socket.inet_ntoa(struct.pack("I", uint_value))
 						else:
 							retdict[0][int(col.contents.column)]["value"] = col.contents.data.integer.contents.value
 					col = col.contents.next
@@ -823,8 +843,8 @@ class netsnmpAgent(object):
 						rootoidlen + 2 + indexoidlen
 					)
 
-					# And finally do away with anything left of the last dot
-					indices = oidcstr.value.split(".")[-1].replace('"', '')
+					# And finally do away with anything left of the first dot
+					indices = oidcstr.value.split(".", 1)[1].replace('"', '')
 
 					# If it's a string, remove the double quotes. If it's a
 					# string containing an integer, make it one
@@ -843,6 +863,12 @@ class netsnmpAgent(object):
 								retdict[indices][int(data.contents.column)] = ctypes.string_at(data.contents.data.string, data.contents.data_len)
 							elif data.contents.type == ASN_COUNTER64:
 								retdict[indices][int(data.contents.column)] = data.contents.data.counter64.contents.value
+							elif data.contents.type == ASN_IPADDRESS:
+								uint_value = ctypes.cast((ctypes.c_int*1)(
+									data.contents.data.integer.contents.value),
+									ctypes.POINTER(ctypes.c_uint)
+									).contents.value
+								retdict[indices][int(data.contents.column)] = socket.inet_ntoa(struct.pack("I", uint_value))
 							else:
 								retdict[indices][int(data.contents.column)] = data.contents.data.integer.contents.value
 						else:


### PR DESCRIPTION
Add missing attributes to class `IpAddress` and adjust byte order as needed.

If `IpAddress` is used as table index, pass it to Net-SNMP in host byte order. Else pass it in network byte order. See https://sourceforge.net/p/net-snmp/bugs/2136 for details why this is necessary.

Improve string representation of `IpAddress` in `Table.value()`.

Note:
In `IpAddress.cref()` I don't store a reference to `_cidx` at "self". This is only safe, if `_cidx` is consumed by a Net-SNMP function that copies the value (like `snmp_varlist_add_variable`). If it was used by Net-SNMP as raw pointer, Pythons reference counting could delete the object while Net-SNMP still wants to access it.

This changes have been tested on x86_64 (little endian) and mips64 (big endian) architecture.