### PR TITLE
Fix handling of OctetStrings with NUL bytes

### DIFF
--- a/netsnmpvartypes.py
+++ b/netsnmpvartypes.py
@@ -225,10 +225,20 @@ class _String(_MaxSizeVarType):
 
 		super(_String, self).__init__(initval, MAX_STRING_SIZE)
 
-# Whereas an OctetString can contain UTF-8 encoded characters, a
-# DisplayString is restricted to ASCII characters only.
+# Whereas an OctetString can contain all byte values, a DisplayString is
+# restricted to ASCII characters only.
 class OctetString(_String):
-	pass
+	def __init__(self, initval = ""):
+		super(OctetString, self).__init__(initval)
+		self._data_size = len(b(initval))
+
+	def value(self):
+		val = self._cvar.raw
+		if hasattr(self, "_watcher"):
+			size = self._watcher.contents.data_size
+		else:
+			size = self._data_size
+		return u(val[:size])
 
 class DisplayString(_String):
 	pass

--- a/netsnmpvartypes.py
+++ b/netsnmpvartypes.py
@@ -238,7 +238,7 @@ class OctetString(_String):
 			size = self._watcher.contents.data_size
 		else:
 			size = self._data_size
-		return u(val[:size])
+		return b(val[:size])
 
 class DisplayString(_String):
 	pass

--- a/tests/test_03_netsnmpagent_snmpobjs.py
+++ b/tests/test_03_netsnmpagent_snmpobjs.py
@@ -1369,6 +1369,36 @@ def test_GET_SET_OctetStringWithoutInterval_abcdef_eq_abcdef():
 	eq_(data, "abcdef")
 
 @timed(1)
+def test_SET_OctetStringWithNULBytes():
+	""" SET(OctetString(), 0x00110022) == 0x00110022
+
+	This tests that calling snmpset on a previously instantiated scalar
+	variable of type OctetString and the string "abcdef" as value (this was
+	confirmed by an earlier test) with the new value 0x00110022 results in
+	the netsnmpagent SNMP object returning "\\x00\\x11\\x00\\x22" as its
+	value, too. """
+
+	global testenv, settableOctetString
+
+	print(testenv.snmpset("TEST-MIB::testOctetStringNoInitval.0", "00110022", "x"))
+
+	eq_(settableOctetString.value(), "\x00\x11\x00\x22")
+
+@timed(1)
+def test_GET_SET_OctetStringWithNULBytes():
+	""" GET(SET(OctetString(), 0x00110022)) == 0x00110022
+
+	This tests that calling snmpget on the previously instantiated scalar
+	variable of type OctetString that has just been set to 0x00110022 also
+	returns this new variable when accessed through snmpget. """
+
+	global testenv
+
+	(data, datatype) = testenv.snmpget("TEST-MIB::testOctetStringNoInitval.0")
+	eq_(datatype, "Hex-STRING")
+	eq_(data, "00 11 00 22")
+
+@timed(1)
 def test_GET_DisplayStringWithoutInitval_eq_Empty():
 	""" GET(DisplayString()) == ""
 

--- a/tests/test_03_netsnmpagent_snmpobjs.py
+++ b/tests/test_03_netsnmpagent_snmpobjs.py
@@ -1352,7 +1352,7 @@ def test_SET_OctetStringWithoutInterval_abcdef_eq_abcdef():
 
 	print(testenv.snmpset("TEST-MIB::testOctetStringNoInitval.0", "abcdef", "s"))
 
-	eq_(settableOctetString.value(), "abcdef")
+	eq_(settableOctetString.value(), b"abcdef")
 
 @timed(1)
 def test_GET_SET_OctetStringWithoutInterval_abcdef_eq_abcdef():
@@ -1382,7 +1382,7 @@ def test_SET_OctetStringWithNULBytes():
 
 	print(testenv.snmpset("TEST-MIB::testOctetStringNoInitval.0", "00110022", "x"))
 
-	eq_(settableOctetString.value(), "\x00\x11\x00\x22")
+	eq_(settableOctetString.value(), b"\x00\x11\x00\x22")
 
 @timed(1)
 def test_GET_SET_OctetStringWithNULBytes():


### PR DESCRIPTION
This changes the `OctetString` class to access the C buffer using `.raw` instead of `.value` to bypass the NUL termination checks. For that it must handle the data size itself.

I think `OctetString.value()` should return a `bytes()` array instead of a string since decoding might fail for some values? (I did not change that since it would break the API and I don't know how you rate API stability in this project.)

FTR, as in #28 I use `OctetString` for MAC addresses, which may contain NUL bytes.