### PR TITLE
Add support for traps

### DIFF
--- a/examples/run_simple_agent.sh
+++ b/examples/run_simple_agent.sh
@@ -86,6 +86,7 @@ echo "    snmpwalk -v 2c -c public -M+. localhost:5555 SIMPLE-MIB::simpleMIB"
 echo "    snmptable -v 2c -c public -M+. -Ci localhost:5555 SIMPLE-MIB::firstTable"
 echo "    snmpget -v 2c -c public -M+. localhost:5555 SIMPLE-MIB::simpleInteger.0"
 echo "    snmpset -v 2c -c simple -M+. localhost:5555 SIMPLE-MIB::simpleInteger.0 i 123"
+echo "    snmptrapd -f -Lo localhost:5556"
 echo ""
 
 # Workaround to have CTRL-C not generate any visual feedback (we don't do any

--- a/netsnmpapi.py
+++ b/netsnmpapi.py
@@ -219,6 +219,7 @@ for f in [ libnsa.netsnmp_create_handler_registration ]:
 # include/net-snmp/library/asn1.h
 ASN_INTEGER                             = 0x02
 ASN_OCTET_STR                           = 0x04
+ASN_OBJECT_ID                           = 0x06
 ASN_OPAQUE_TAG2                         = 0x30
 ASN_APPLICATION                         = 0x40
 

--- a/netsnmpapi.py
+++ b/netsnmpapi.py
@@ -438,3 +438,35 @@ for f in [ libnsa.agent_check_and_process ]:
 		ctypes.c_int                    # int block
 	]
 	f.restype = ctypes.c_int
+
+
+def read_objid(objid_str):
+	"""
+    python wrapper for libnetsnmpagent read_objid function
+
+    Convert string OID array with correct length
+    """
+
+	# We can't know the length of the internal OID representation
+	# beforehand, so we use a MAX_OID_LEN sized buffer for the call to
+	# read_objid() below
+	oid = (c_oid * MAX_OID_LEN)()
+	oid_len = ctypes.c_size_t(MAX_OID_LEN)
+
+	# Let libsnmpagent parse the OID
+	if libnsa.read_objid(
+			b(objid_str),
+			ctypes.cast(ctypes.byref(oid), c_oid_p),
+			ctypes.byref(oid_len)
+	) == 0:
+		raise Exception("read_objid({0}) failed!".format(objid_str))
+
+	# trim oid array to correct length
+	return (c_oid * oid_len.value)(*(oid[0:oid_len.value]))
+
+
+def format_objid(oid):
+	"""
+    Format objid as string
+    """
+	return ".".join([str(o) for o in oid])


### PR DESCRIPTION
Inspired by #22 but done completely differently. It is not using pdu so it is not affected by incompatibility introduced in Net-SNMP v5.8.

Function parameters are different and simplified. You can just send numeric trap for SNMPv1 or OID trap for SNMPv2c and SNMPv3.

Actual version of the trap is configured via snmpd.conf.

Variables are not send by raw values but must be encapsulated in variable type. This help serializing with already defined code.

To send trap, you can reuse already registred variables
```python

simpleUnsignedRO = agent.Unsigned32(
	oidstr   = "SIMPLE-MIB::simpleUnsignedRO",
	writable = False
)

...

agent.send_trap(
	trap='SIMPLE-MIB::simpleUnsignedROChange',
	varlist={
		'SIMPLE-MIB::simpleUnsignedRO.0': simpleUnsignedRO,
	}
)
```

Or send completely unrelated new value
```python
agent.send_trap(
	trap='SIMPLE-MIB::simpleUnsignedROChange',
	varlist={
		'SIMPLE-MIB::simpleUnsignedRO.0': agent.Unsigned32(123456),
	}
)
```


Function `read_objid` is extracted, because it is used many times. This function can handle correctly numeric OID representations like `".1.3.6.1.2.1.1.3.0"` so there is no need to reimplement this in python. This is the reason, why this part is heavily simplified.
