### PR TITLE
fix(Table): fix use-after-free

### DIFF
--- a/netsnmpagent.py
+++ b/netsnmpagent.py
@@ -674,14 +674,12 @@ class netsnmpAgent(object):
 				return retdict
 
 			def clear(self):
-				row = self._dataset.contents.table.contents.first_row
-				while bool(row):
-					nextrow = row.contents.next
+				table = self._dataset.contents.table.contents
+				while table.first_row:
 					libnsX.netsnmp_table_dataset_remove_and_delete_row(
 						self._dataset,
-						row
+						table.first_row
 					)
-					row = nextrow
 				if self._counterobj:
 					self._counterobj.update(0)
 


### PR DESCRIPTION
Simplify iterating over elements by only handling `first_row`, thus eliminating use-after-free behavior of ctypes.pointer.

Fixes #52